### PR TITLE
feat: Upgrade php to 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.php_cs.cache
 /composer.lock
 .phpunit.result.cache
+/data

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,7 +4,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/tests');
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
         '@PHP71Migration:risky' => true,
@@ -13,13 +13,14 @@ return PhpCsFixer\Config::create()
         'blank_line_after_opening_tag' => true,
         'concat_space' => ['spacing' => 'one'],
         'declare_strict_types' => true,
+        'global_namespace_import' => ['import_classes' => true, 'import_constants' => true, 'import_functions' => true],
         'increment_style' => ['style' => 'post'],
-        'is_null' => ['use_yoda_style' => false],
+        'is_null' => false,
         'list_syntax' => ['syntax' => 'short'],
-        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'method_argument_space' => ['on_multiline' => "ensure_fully_multiline"],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,
-        'no_multiline_whitespace_before_semicolons' => true,
+        'multiline_whitespace_before_semicolons' => false,
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => true,
         'no_useless_else' => true,

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.1",
         "pimple/pimple": "^3.5",
-        "doctrine/orm": "^2.14",
+        "doctrine/orm": "^2.13",
         "symfony/cache": "^6.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,14 @@
     "type": "library",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=7.1",
-        "pimple/pimple": "~3.2",
-        "doctrine/orm": "~2.6"
+        "php": "^8.1",
+        "pimple/pimple": "^3.5",
+        "doctrine/orm": "^2.14",
+        "symfony/cache": "^6.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8",
-        "friendsofphp/php-cs-fixer": "^2.14"
+        "phpunit/phpunit": "^9.5",
+        "friendsofphp/php-cs-fixer": "3.13"
     },
     "suggest": {
         "ext-memcached": "Allows usage of Memcached.",
@@ -34,7 +35,7 @@
             "@phpunit"
         ],
         "phpunit": "vendor/bin/phpunit --verbose",
-        "lint": "php-cs-fixer fix --verbose --show-progress=estimating",
-        "lint:check": "php-cs-fixer fix --dry-run --verbose --show-progress=estimating"
+        "lint": "php-cs-fixer fix --verbose --show-progress=dots",
+        "lint:check": "php-cs-fixer fix --dry-run --verbose --show-progress=dots"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,12 @@
         }
     },
     "scripts": {
-        "test": [
+        "check": [
             "@lint:check",
-            "@phpunit"
+            "@static-analysis",
+            "@test"
         ],
-        "phpunit": "vendor/bin/phpunit --verbose",
+        "test": "vendor/bin/phpunit --verbose",
         "lint": "php-cs-fixer fix --verbose --show-progress=dots",
         "lint:check": "php-cs-fixer fix --dry-run --verbose --show-progress=dots",
         "static-analysis": [

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "friendsofphp/php-cs-fixer": "3.13"
+        "friendsofphp/php-cs-fixer": "3.13",
+        "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan-mockery": "^1.1"
     },
     "suggest": {
         "ext-memcached": "Allows usage of Memcached.",
@@ -36,6 +38,9 @@
         ],
         "phpunit": "vendor/bin/phpunit --verbose",
         "lint": "php-cs-fixer fix --verbose --show-progress=dots",
-        "lint:check": "php-cs-fixer fix --dry-run --verbose --show-progress=dots"
+        "lint:check": "php-cs-fixer fix --dry-run --verbose --show-progress=dots",
+        "static-analysis": [
+            "phpstan analyse --ansi --memory-limit=-1"
+        ]
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+includes:
+    - vendor/phpstan/phpstan-mockery/extension.neon
+
+parameters:
+    level: max
+    paths:
+        - src
+        - tests
+    tmpDir: data/cache/phpstan
+    checkGenericClassInNonGenericObjectType: false

--- a/src/Provider/DbalServiceProvider.php
+++ b/src/Provider/DbalServiceProvider.php
@@ -35,9 +35,15 @@ class DbalServiceProvider implements ServiceProviderInterface
                 $app['dbs.options'] = ['default' => $app['db.options'] ?? []];
             }
 
+            /** @var mixed[] $tmp */
             $tmp = $app['dbs.options'];
+
+            /** @var mixed[] $defaultOptions */
+            $defaultOptions = $app['db.default_options'];
+
+            /** @var mixed[] $options */
             foreach ($tmp as $name => &$options) {
-                $options = array_replace($app['db.default_options'], $options);
+                $options = array_replace($defaultOptions, $options);
 
                 if (!isset($app['dbs.default'])) {
                     $app['dbs.default'] = $name;

--- a/tests/Provider/DbalServiceProviderTest.php
+++ b/tests/Provider/DbalServiceProviderTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Linio\Doctrine\Provider;
 
+use PDO;
+use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 
-class DbalServiceProviderTest extends \PHPUnit_Framework_TestCase
+class DbalServiceProviderTest extends TestCase
 {
     public function testOptionsInitializer(): void
     {
@@ -18,7 +20,7 @@ class DbalServiceProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleConnection(): void
     {
-        if (!in_array('sqlite', \PDO::getAvailableDrivers())) {
+        if (!in_array('sqlite', PDO::getAvailableDrivers())) {
             $this->markTestSkipped('pdo_sqlite is not available');
         }
 
@@ -31,15 +33,14 @@ class DbalServiceProviderTest extends \PHPUnit_Framework_TestCase
         $params = $db->getParams();
         $this->assertArrayHasKey('memory', $params);
         $this->assertTrue($params['memory']);
-        $this->assertInstanceof('Doctrine\DBAL\Driver\PDOSqlite\Driver', $db->getDriver());
-        $this->assertEquals(22, $container['db']->fetchColumn('SELECT 22'));
-
+        $this->assertInstanceof('Doctrine\DBAL\Driver\PDO\Sqlite\Driver', $db->getDriver());
+        $this->assertEquals(22, $container['db']->fetchOne('SELECT 22'));
         $this->assertSame($container['dbs']['default'], $db);
     }
 
     public function testMultipleConnections(): void
     {
-        if (!in_array('sqlite', \PDO::getAvailableDrivers())) {
+        if (!in_array('sqlite', PDO::getAvailableDrivers())) {
             $this->markTestSkipped('pdo_sqlite is not available');
         }
 
@@ -55,8 +56,8 @@ class DbalServiceProviderTest extends \PHPUnit_Framework_TestCase
         $params = $db->getParams();
         $this->assertArrayHasKey('memory', $params);
         $this->assertTrue($params['memory']);
-        $this->assertInstanceof('Doctrine\DBAL\Driver\PDOSqlite\Driver', $db->getDriver());
-        $this->assertEquals(22, $container['db']->fetchColumn('SELECT 22'));
+        $this->assertInstanceof('Doctrine\DBAL\Driver\PDO\Sqlite\Driver', $db->getDriver());
+        $this->assertEquals(22, $container['db']->fetchOne('SELECT 22'));
 
         $this->assertSame($container['dbs']['sqlite1'], $db);
 


### PR DESCRIPTION
This PR upgrades PHP version to 8.1 along with its dependences in order to fulfil this new constraint, with some extras.

- Upgrade PHP version to 8.1.
- Upgrade dependencies.
- Added `symfony/cache` dependency. This is because doctrine/cache (2.x) has removed cache implementation and now only mantains its interface for some backward compatibility, so we use symfony/cache implementations to replace these. More information [here](https://www.doctrine-project.org/projects/doctrine-cache/en/current/index.html#deprecation-notice).
- Added static analysis through phpstan, and refactored some code in order to fulfil its rules.